### PR TITLE
Fix section editing bug

### DIFF
--- a/syntax/headeratx.php
+++ b/syntax/headeratx.php
@@ -18,7 +18,7 @@ class syntax_plugin_markdowku_headeratx extends DokuWiki_Syntax_Plugin {
   
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern(
-            '\n\#{1,6}[ \t]*.+?[ \t]*\#*(?=\n+)',
+            '^\#{1,6}[ \t]*.+?[ \t]*\#*(?=\n+)',
             'base',
             'plugin_markdowku_headeratx');
     }
@@ -39,7 +39,7 @@ class syntax_plugin_markdowku_headeratx extends DokuWiki_Syntax_Plugin {
         if ($handler->getStatus('section'))
             $handler->_addCall('section_close', array(), $pos);
         if ($level <= $conf['maxseclevel']) {
-            $handler->setStatus('section_edit_start', $pos);
+            $handler->setStatus('section_edit_start', $pos-1);
             $handler->setStatus('section_edit_level', $level);
             $handler->setStatus('section_edit_title', $title);
         }

--- a/syntax/headersetext.php
+++ b/syntax/headersetext.php
@@ -20,27 +20,27 @@ class syntax_plugin_markdowku_headersetext extends DokuWiki_Syntax_Plugin {
 
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern(
-            '\n[^\n]+[ \t]*\n=+[ \t]*(?=\n)',
+            '^[^\n]+[ \t]*\n=+[ \t]*(?=\n)',
             'base',
             'plugin_markdowku_headersetext');
 
         $this->Lexer->addSpecialPattern(
-            '\n[^\n]+[ \t]*\n-+[ \t]*(?=\n)',
+            '^[^\n]+[ \t]*\n-+[ \t]*(?=\n)',
             'base',
             'plugin_markdowku_headersetext');
     }
 
     function handle($match, $state, $pos, Doku_Handler $handler) {
-        $title = preg_replace('/^\n(.+?)[ \t]*\n.*/', '\1', $match);
+        $title = preg_replace('/^(.+?)[ \t]*\n.*/', '\1', $match);
         $title = trim($title);
-        if (preg_match('/^\n(.+?)[ \t]*\n=/', $match))
+        if (preg_match('/^(.+?)[ \t]*\n=/', $match))
             $level = 1;
-        if (preg_match('/^\n(.+?)[ \t]*\n-/', $match))
+        if (preg_match('/^(.+?)[ \t]*\n-/', $match))
             $level = 2;
 
         if ($handler->getStatus('section'))
             $handler->_addCall('section_close', array(), $pos);
-        $handler->setStatus('section_edit_start', $pos);
+        $handler->setStatus('section_edit_start', $pos-1);
         $handler->setStatus('section_edit_level', $level);
         $handler->setStatus('section_edit_title', $title);
         $handler->_addCall('header', array($title, $level, $pos), $pos);


### PR DESCRIPTION
Editing sections often remove the last character of the previous
section. We can't have that.

The workaround has been to try to remember to always add an extra
newline manually at the start of each section we're editing but that
gets tedious and doesn't fix all issues.
